### PR TITLE
Add support for multithreaded calls to refresh access requests in webclient

### DIFF
--- a/SafeExchange.Client.Web.Components/Classes/DataFetchedEventArgs.cs
+++ b/SafeExchange.Client.Web.Components/Classes/DataFetchedEventArgs.cs
@@ -1,0 +1,17 @@
+﻿/// <summary>
+/// DataFetchedEventArgs
+/// </summary>
+
+namespace SafeExchange.Client.Web.Components.Classes
+{
+    using SafeExchange.Client.Common.Model;
+    using System;
+
+    public class DataFetchedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Data fetch response status.
+        /// </summary>
+        public ResponseStatus ResponseStatus { get; set; }
+    }
+}

--- a/SafeExchange.Client.Web.Components/Pages/AccessRequests.razor
+++ b/SafeExchange.Client.Web.Components/Pages/AccessRequests.razor
@@ -1,11 +1,14 @@
-﻿@using SafeExchange.Client.Common
+﻿@using Microsoft.Extensions.Logging;
+@using SafeExchange.Client.Common
 @using SafeExchange.Client.Common.Model
 @using Microsoft.AspNetCore.Components.WebAssembly.Authentication
+@using SafeExchange.Client.Web.Components.Classes;
 @using SafeExchange.Client.Web.Components.Helpers
 @using SafeExchange.Client.Web.Components.Model
 
 @inject StateContainer StateContainer
 @inject ApiClient apiClient
+@inject ILogger<AccessRequests> logger
 
 <!-- Modal -->
 <div class="modal fade" id="cancellationDialog" tabindex="-1" role="dialog" aria-labelledby="modalLabel" aria-hidden="true">
@@ -67,9 +70,18 @@
 
                 @if (this.IncomingAccessRequests.Count == 0)
                 {
-                    <p class="my-4">
-                        - No incoming access requests -
-                    </p>
+                    @if (this.StateContainer.IsFetchingAccessRequests)
+                    {
+                        <div class="spinner-border spinner-border-sm" role="status">
+                            <span class="visually-hidden">In progress...</span>
+                        </div>
+                    }
+                    else
+                    {
+                        <p class="my-4">
+                            - No incoming access requests -
+                        </p>
+                    }
                 }
             </div>
             <div class="tab-pane fade" id="outgoing" role="tabpanel" aria-labelledby="outgoing-tab">
@@ -91,11 +103,19 @@
 
                 @if (this.OutgoingAccessRequests.Count == 0)
                 {
-                    <p class="my-4">
-                        - No outgoing access requests -
-                    </p>
+                    @if (this.StateContainer.IsFetchingAccessRequests)
+                    {
+                        <div class="spinner-border spinner-border-sm" role="status">
+                            <span class="visually-hidden">In progress...</span>
+                        </div>
+                    }
+                    else
+                    {
+                        <p class="my-4">
+                            - No outgoing access requests -
+                        </p>
+                    }
                 }
-
             </div>
         </div>
     </div>
@@ -110,9 +130,9 @@
 
     private NotificationData Notification;
 
-    private IList<AccessRequest> IncomingAccessRequests;
+    private IList<AccessRequest> IncomingAccessRequests = new List<AccessRequest>();
 
-    private IList<AccessRequest> OutgoingAccessRequests;
+    private IList<AccessRequest> OutgoingAccessRequests = new List<AccessRequest>();
 
     private AccessRequest RequestToCancel;
 
@@ -128,32 +148,46 @@
 
     private async Task FetchAccessRequestsAsync()
     {
+        this.logger.LogDebug($"{nameof(FetchAccessRequestsAsync)} started.");
+
         this.StateContainer.IsInProgress = true;
+        this.logger.LogDebug($"Subscribing to state container {nameof(this.StateContainer.OnAccessRequestsFetched)}.");
+        this.StateContainer.OnAccessRequestsFetched += this.OnAccessRequestsFetched;
+
+        var currentUserUpn = TokenHandler.GetName(authenticationState.User);
+        await this.StateContainer.TryFetchAccessRequestsAsync(this.apiClient, currentUserUpn);
+
+        this.logger.LogDebug($"{nameof(FetchAccessRequestsAsync)} finished.");
+    }
+
+    private void OnAccessRequestsFetched(object? sender, DataFetchedEventArgs e)
+    {
+        this.logger.LogDebug($"{nameof(OnAccessRequestsFetched)} finished.");
+
         try
         {
-            var currentUserUpn = TokenHandler.GetName(authenticationState.User);
-            var reply = await this.StateContainer.TryFetchAccessRequestsAsync(this.apiClient, currentUserUpn);
-            if (!"ok".Equals(reply.Status))
+            if (!"ok".Equals(e.ResponseStatus.Status))
             {
                 this.Notification = new NotificationData()
-                {
-                    Type = NotificationType.Warning,
-                    Status = reply.Status,
-                    Message = reply.Error
-                };
+                    {
+                        Type = NotificationType.Warning,
+                        Status = e.ResponseStatus.Status,
+                        Message = e.ResponseStatus.Error ?? string.Empty
+                    };
                 return;
             }
 
             this.IncomingAccessRequests = new List<AccessRequest>(this.StateContainer.IncomingAccessRequests);
             this.OutgoingAccessRequests = new List<AccessRequest>(this.StateContainer.OutgoingAccessRequests);
         }
-        catch (AccessTokenNotAvailableException exception)
-        {
-            exception.Redirect();
-        }
         finally
         {
+            this.logger.LogDebug($"Unsubscribing from state container {nameof(this.StateContainer.OnAccessRequestsFetched)}.");
+            this.StateContainer.OnAccessRequestsFetched -= this.OnAccessRequestsFetched;
             this.StateContainer.IsInProgress = false;
+
+            this.StateHasChanged();
+            this.logger.LogDebug($"{nameof(OnAccessRequestsFetched)} finished.");
         }
     }
 

--- a/SafeExchange.PWA/wwwroot/appsettings.json
+++ b/SafeExchange.PWA/wwwroot/appsettings.json
@@ -1,4 +1,9 @@
 {
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
   "BackendApi": {
     "BaseAddress": "https://safeexchange-staging.azurewebsites.net/api/"
   },
@@ -6,7 +11,7 @@
     "AppServerPublicKey": ""
   },
   "AzureAdB2C": {
-    "Authority": "https://login.microsoftonline.com/consumers",
+    "Authority": "https://login.microsoftonline.com/1472703e-99d8-45ee-aeac-7ec3ae9ab104",
     "ClientId": "fdfa17b0-db9b-4927-8b83-07055ae70c39",
     "ValidateAuthority": false
   },


### PR DESCRIPTION
Add support for multithreaded calls to refresh access requests in webclient.
When a user opens 'accessrequests' web page, there should not be duplicates or requests.