### PR TITLE
Show expiration datetime in local format; convert to UTC when sending…

### DIFF
--- a/SafeExchange.Client.Common/Model/ExpirationMetadata.cs
+++ b/SafeExchange.Client.Common/Model/ExpirationMetadata.cs
@@ -20,8 +20,12 @@ namespace SafeExchange.Client.Common.Model
 
         public ExpirationMetadata(ExpirationSettingsOutput source)
         {
+            var expireAt = source.ExpireAt.Kind == DateTimeKind.Unspecified
+                ? DateTime.SpecifyKind(source.ExpireAt, DateTimeKind.Utc)
+                : source.ExpireAt;
+
             this.ScheduleExpiration = source.ScheduleExpiration;
-            this.ExpireAt = source.ExpireAt;
+            this.ExpireAt = expireAt.ToLocalTime();
             this.ExpireOnIdleTime = source.ExpireOnIdleTime;
             this.IdleTimeToExpire = source.IdleTimeToExpire;
         }
@@ -71,12 +75,19 @@ namespace SafeExchange.Client.Common.Model
         public override string? ToString()
             =>  $"ScheduleExpiration: {this.ScheduleExpiration}, ExpireAt: {this.ExpireAt}, ExpireOnIdleTime: {this.ExpireOnIdleTime}, IdleTimeToExpire: {this.IdleTimeToExpire}";
 
-        public ExpirationSettingsInput ToDto() => new ExpirationSettingsInput()
+        public ExpirationSettingsInput ToDto()
         {
-            ScheduleExpiration = this.ScheduleExpiration,
-            ExpireAt = this.ExpireAt,
-            ExpireOnIdleTime = this.ExpireOnIdleTime,
-            IdleTimeToExpire = this.IdleTimeToExpire
-        };
+            var expireAt = this.ExpireAt.Kind == DateTimeKind.Unspecified
+                ? DateTime.SpecifyKind(this.ExpireAt, DateTimeKind.Local)
+                : this.ExpireAt;
+
+            return new ExpirationSettingsInput()
+            {
+                ScheduleExpiration = this.ScheduleExpiration,
+                ExpireAt = expireAt.ToUniversalTime(),
+                ExpireOnIdleTime = this.ExpireOnIdleTime,
+                IdleTimeToExpire = this.IdleTimeToExpire
+            };
+        }
     }
 }

--- a/SafeExchange.Client.Web.Components/Pages/CreateData.razor
+++ b/SafeExchange.Client.Web.Components/Pages/CreateData.razor
@@ -312,7 +312,7 @@
             ExpirationMetadata = new ExpirationMetadata()
             {
                 ScheduleExpiration = false,
-                ExpireAt = DateTime.MinValue,
+                ExpireAt = DateTime.Now,
                 ExpireOnIdleTime = false,
                 IdleTimeToExpire = TimeSpan.Zero
             }
@@ -465,6 +465,7 @@
 
         try
         {
+            this.SpecifyExpirationDateTimeKind();
             await using var timer = new Timer(_ => InvokeAsync(() => StateHasChanged()), null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
             var result = await apiClient.CreateFromCompoundModelAsync(this.compoundModel, this.Attachments);
             if (!"ok".Equals(result.Status))
@@ -510,5 +511,14 @@
     private string GetViewUri(string objectName)
     {
         return $"{NavManager.BaseUri.TrimEnd('/')}/viewdata/{objectName}";
+    }
+
+    private void SpecifyExpirationDateTimeKind()
+    {
+        if (this.compoundModel.Metadata.ExpirationMetadata.ExpireAt.Kind == DateTimeKind.Unspecified)
+        {
+            this.compoundModel.Metadata.ExpirationMetadata.ExpireAt =
+                DateTime.SpecifyKind(this.compoundModel.Metadata.ExpirationMetadata.ExpireAt, DateTimeKind.Local);
+        }
     }
 }

--- a/SafeExchange.Client.Web.Components/Pages/EditData.razor
+++ b/SafeExchange.Client.Web.Components/Pages/EditData.razor
@@ -619,7 +619,7 @@
             // TODO: would need to have custom control for expiration time to handle seconds. Until then just dropping seconds here.
             var expireAt = this.compoundModel.Metadata.ExpirationMetadata.ExpireAt;
             expireAt = new DateTime(expireAt.Year, expireAt.Month, expireAt.Day, expireAt.Hour, expireAt.Minute, 0, expireAt.Kind);
-            this.compoundModel.Metadata.ExpirationMetadata.ExpireAt = expireAt;
+            this.compoundModel.Metadata.ExpirationMetadata.ExpireAt = expireAt.ToLocalTime();
 
             this.compoundModel.Permissions = compoundModelResult.Result.Permissions;
             this.compoundModel.MainData = compoundModelResult.Result.MainData;
@@ -669,6 +669,7 @@
         this.StateHasChanged();
         try
         {
+            this.SpecifyExpirationDateTimeKind();
             await using var timer = new Timer(_ => InvokeAsync(() => StateHasChanged()), null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
             if (!this.compoundModel.Metadata.ExpirationMetadata.Equals(this.originalMetadata.ExpirationMetadata))
             {
@@ -849,5 +850,14 @@
     private string GetViewUri(string objectName)
     {
         return $"{NavManager.BaseUri.TrimEnd('/')}/viewdata/{objectName}";
+    }
+
+    private void SpecifyExpirationDateTimeKind()
+    {
+        if (this.compoundModel.Metadata.ExpirationMetadata.ExpireAt.Kind == DateTimeKind.Unspecified)
+        {
+            this.compoundModel.Metadata.ExpirationMetadata.ExpireAt =
+                DateTime.SpecifyKind(this.compoundModel.Metadata.ExpirationMetadata.ExpireAt, DateTimeKind.Local);
+        }
     }
 }


### PR DESCRIPTION
… to server, and vice a versa; assign today's datetime as the default value for expiration on the webpage when creating secrets.