### PR TITLE
feat(s2s): tenant picker on registration + application search picker on access list

### DIFF
--- a/SafeExchange.Client.Common/ApiClient/ApiClient.S2SApps.cs
+++ b/SafeExchange.Client.Common/ApiClient/ApiClient.S2SApps.cs
@@ -27,6 +27,15 @@ namespace SafeExchange.Client.Common
             return await DeserializeOrErrorAsync<S2SApp>(response);
         }
 
+        /// <summary>GET /v2/s2sapps-allowed-tenants — tenants the operator allows for S2S registration.</summary>
+        public async Task<BaseResponseObject<List<S2SAllowedTenant>>> GetS2SAllowedTenantsAsync()
+        {
+            var url = new Uri(this.client.BaseAddress!, $"{ApiVersion}/s2sapps-allowed-tenants");
+            using var http = new HttpRequestMessage(HttpMethod.Get, url);
+            var response = await this.client.SendAsync(http);
+            return await DeserializeOrErrorAsync<List<S2SAllowedTenant>>(response);
+        }
+
         /// <summary>GET /v2/s2sapps/mine — apps where the caller is a direct user-owner.</summary>
         public async Task<BaseResponseObject<List<S2SAppOverview>>> ListMyS2SAppsAsync()
         {

--- a/SafeExchange.Client.Common/ApiClient/ApiClient.cs
+++ b/SafeExchange.Client.Common/ApiClient/ApiClient.cs
@@ -834,6 +834,12 @@ namespace SafeExchange.Client.Common
                 return await client.PostAsJsonAsync($"{ApiVersion}/group-search", input);
             });
 
+        public async Task<BaseResponseObject<List<Application>>> SearchApplicationsAsync(SearchInput input)
+            => await this.ProcessResponseAsync<List<Application>>(async () =>
+            {
+                return await client.PostAsJsonAsync($"{ApiVersion}/application-search", input);
+            });
+
         #endregion
 
         private async Task<BaseResponseObject<T>> ProcessResponseAsync<T>(Func<Task<HttpResponseMessage>> asyncHttpCall) where T : class

--- a/SafeExchange.Client.Common/Model/S2SAppModels.cs
+++ b/SafeExchange.Client.Common/Model/S2SAppModels.cs
@@ -54,6 +54,13 @@ namespace SafeExchange.Client.Common.Model
         public List<S2SAppOwner> Owners { get; set; } = new();
     }
 
+    /// <summary>A tenant the operator allows for S2S app registration (GET /v2/s2sapps-allowed-tenants).</summary>
+    public class S2SAllowedTenant
+    {
+        public string TenantId { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+    }
+
     public class S2SAppOverview
     {
         public string DisplayName { get; set; } = string.Empty;

--- a/SafeExchange.Client.Web.Components/Pages/CreateData.razor
+++ b/SafeExchange.Client.Web.Components/Pages/CreateData.razor
@@ -427,7 +427,6 @@
         }
 
         this.editContext = new EditContext(this.compoundModel);
-        await this.StateContainer.TryFetchRegisteredApplications(this.apiClient);
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/SafeExchange.Client.Web.Components/Pages/CreateData.razor
+++ b/SafeExchange.Client.Web.Components/Pages/CreateData.razor
@@ -42,6 +42,19 @@
     </ItemTemplate>
 </ItemSearchDialog>
 
+<ItemSearchDialog TItem="Application" @ref="this.applicationPickDialog" DialogTitle="Find application" Placeholder="Search applications..." OnItemPickedCallback="this.FinishApplicationPick" SearchItemsAsyncCallback="this.SearchApplicationsAsync" OnClosedCallback="() => this.StateHasChanged()">
+    <ItemTemplate Context="application">
+        <div class="px-2">
+            <div class="text-truncate">
+                @application.DisplayName
+            </div>
+            <div class="text-truncate">
+                <small>@application.AadClientId &middot; @application.AadTenantId</small>
+            </div>
+        </div>
+    </ItemTemplate>
+</ItemSearchDialog>
+
 @if (this.Notification != null)
 {
     <div class="alert alert-dismissible @(this.Notification.GetAlertClass() ?? "alert-primary")" role="alert">
@@ -284,30 +297,16 @@
 
                     case (SubjectType.Application):
                         <div class="col">
-                            <div class="form-floating">
-                                <InputSelect id="@($"application-input-{i}")" class="form-select" disabled="@this.StateContainer.IsInProgress" @bind-Value="compoundModel.Permissions[tempIndex].SubjectName" placeholder="Application" aria-describedby="@($"app-validation-{i}")">
-                                    @if (!this.StateContainer.IsFetchingApplications)
-                                    {
-                                        if ((this.StateContainer.RegisteredApplications?.Count ?? 0) > 0)
-                                        {
-                                            foreach (var application in this.StateContainer.RegisteredApplications.Where(a => a.Enabled))
-                                            {
-                                                <option value="@application.DisplayName">@application.DisplayName</option>
-                                            }
-                                        }
-                                        else
-                                        {
-                                            <option value="">- No Applications -</option>
-                                        }
-                                    }
-                                </InputSelect>
-                                <label for="@($"application-input-{i}")" class="form-label">
-                                    @if (this.StateContainer.IsFetchingApplications)
-                                    {
-                                        <span class="spinner-border spinner-border-sm" role="status"></span>
-                                    }
-                                    Application
-                                </label>
+                            <div class="input-group">
+                                <div class="form-floating">
+                                    <InputText id="@($"application-input-{i}")" class="form-control" readonly disabled="@this.StateContainer.IsInProgress" @bind-Value="this.compoundModel.Permissions[tempIndex].SubjectName" placeholder="Application" aria-describedby="@($"app-validation-{i}")" />
+                                    <label for="@($"application-input-{i}")" class="form-label">Application</label>
+                                </div>
+                                <span class="narrow-floating-group input-group-text">
+                                    <button class="btn" type="button" disabled="@this.StateContainer.IsInProgress" @onclick="@(e => this.StartApplicationPickAsync(tempIndex))" aria-label="Find application">
+                                        <span class="bi bi-search"></span>
+                                    </button>
+                                </span>
                             </div>
                             <ValidationMessage id="@($"app-validation-{i}")" For="@(() => compoundModel.Permissions[tempIndex].SubjectName)" />
                         </div>
@@ -377,6 +376,8 @@
     private ItemSearchDialog<GraphUserOutput> userPickDialog;
 
     private ItemSearchDialog<GraphGroupOutput> groupPickDialog;
+
+    private ItemSearchDialog<Application> applicationPickDialog;
 
     private int currentPermissionItemIndex;
 
@@ -636,6 +637,22 @@
     {
         this.currentPermissionItemIndex = permissionItemIndex;
         await this.groupPickDialog.StartItemSearchAsync();
+    }
+
+    private async Task StartApplicationPickAsync(int permissionItemIndex)
+    {
+        this.currentPermissionItemIndex = permissionItemIndex;
+        await this.applicationPickDialog.StartItemSearchAsync();
+    }
+
+    private async Task<BaseResponseObject<List<Application>>> SearchApplicationsAsync(SearchInput searchInput)
+        => await this.apiClient.SearchApplicationsAsync(searchInput);
+
+    public void FinishApplicationPick(Application pickedApplication)
+    {
+        // Application access grants key on the globally-unique display name.
+        this.compoundModel.Permissions[this.currentPermissionItemIndex].SubjectId = pickedApplication.DisplayName;
+        this.compoundModel.Permissions[this.currentPermissionItemIndex].SubjectName = pickedApplication.DisplayName;
     }
 
     private async Task<BaseResponseObject<List<GraphUserOutput>>> SearchUsersAsync(SearchInput searchInput)

--- a/SafeExchange.Client.Web.Components/Pages/EditData.razor
+++ b/SafeExchange.Client.Web.Components/Pages/EditData.razor
@@ -48,6 +48,19 @@
     </ItemTemplate>
 </ItemSearchDialog>
 
+<ItemSearchDialog TItem="Application" @ref="this.applicationPickDialog" DialogTitle="Find application" Placeholder="Search applications..." OnItemPickedCallback="this.FinishApplicationPick" SearchItemsAsyncCallback="this.SearchApplicationsAsync" OnClosedCallback="() => this.StateHasChanged()">
+    <ItemTemplate Context="application">
+        <div class="px-2">
+            <div class="text-truncate">
+                @application.DisplayName
+            </div>
+            <div class="text-truncate">
+                <small>@application.AadClientId &middot; @application.AadTenantId</small>
+            </div>
+        </div>
+    </ItemTemplate>
+</ItemSearchDialog>
+
 <div class="modal fade" id="deletionDialog" tabindex="-1" role="dialog" aria-labelledby="modalLabel" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -356,30 +369,25 @@
 
                         case (SubjectType.Application):
                             <div class="col">
-                                <div class="form-floating">
-                                    <InputSelect id="@($"application-input-{i}")" class="@(this.IsDeleted(tempIndex)? "form-control text-removed" : "form-control")" disabled="@(tempIndex < this.FixedAccessItemCount || this.StateContainer.IsInProgress)" @bind-Value="compoundModel.Permissions[tempIndex].SubjectName" placeholder="Application" aria-describedby="@($"app-validation-{i}")">
-                                        @if (!this.StateContainer.IsFetchingApplications)
+                                <div class="input-group">
+                                    <div class="form-floating">
+                                        <InputText id="@($"application-input-{i}")" class="@(this.IsDeleted(tempIndex)? "form-control text-removed" : "form-control")" readonly disabled="@(tempIndex < this.FixedAccessItemCount || this.StateContainer.IsInProgress)" @bind-Value="this.compoundModel.Permissions[tempIndex].SubjectName" placeholder="Application" aria-describedby="@($"app-validation-{i}")" />
+                                        <label for="@($"application-input-{i}")" class="form-label">Application</label>
+                                    </div>
+                                    <span class="narrow-floating-group input-group-text">
+                                        @if (tempIndex < this.FixedAccessItemCount)
                                         {
-                                            if ((this.StateContainer.RegisteredApplications?.Count ?? 0) > 0)
-                                            {
-                                                foreach (var application in this.StateContainer.RegisteredApplications.Where(a => a.Enabled))
-                                                {
-                                                    <option value="@application.DisplayName">@application.DisplayName</option>
-                                                }
-                                            }
-                                            else
-                                            {
-                                                <option value="">- No Applications -</option>
-                                            }
+                                            <button class="btn btn-link" type="button" disabled aria-label="Find application">
+                                                <span class="bi bi-search"></span>
+                                            </button>
                                         }
-                                    </InputSelect>
-                                    <label for="@($"application-input-{i}")" class="form-label">
-                                        @if (this.StateContainer.IsFetchingApplications)
+                                        else
                                         {
-                                            <span class="spinner-border spinner-border-sm" role="status"></span>
+                                            <button class="btn" type="button" disabled="@(this.StateContainer.IsInProgress)" @onclick="@(e => this.StartApplicationPickAsync(tempIndex))" aria-label="Find application">
+                                                <span class="bi bi-search"></span>
+                                            </button>
                                         }
-                                        Application
-                                    </label>
+                                    </span>
                                 </div>
                                 <ValidationMessage id="@($"app-validation-{i}")" For="@(() => compoundModel.Permissions[tempIndex].SubjectName)" />
                             </div>
@@ -480,6 +488,8 @@
     private ItemSearchDialog<GraphUserOutput> userPickDialog;
 
     private ItemSearchDialog<GraphGroupOutput> groupPickDialog;
+
+    private ItemSearchDialog<Application> applicationPickDialog;
 
     private int currentPermissionItemIndex;
 
@@ -1146,6 +1156,22 @@
     {
         this.currentPermissionItemIndex = permissionItemIndex;
         await this.groupPickDialog.StartItemSearchAsync();
+    }
+
+    private async Task StartApplicationPickAsync(int permissionItemIndex)
+    {
+        this.currentPermissionItemIndex = permissionItemIndex;
+        await this.applicationPickDialog.StartItemSearchAsync();
+    }
+
+    private async Task<BaseResponseObject<List<Application>>> SearchApplicationsAsync(SearchInput searchInput)
+        => await this.apiClient.SearchApplicationsAsync(searchInput);
+
+    public void FinishApplicationPick(Application pickedApplication)
+    {
+        // Application access grants key on the globally-unique display name.
+        this.compoundModel.Permissions[this.currentPermissionItemIndex].SubjectId = pickedApplication.DisplayName;
+        this.compoundModel.Permissions[this.currentPermissionItemIndex].SubjectName = pickedApplication.DisplayName;
     }
 
     private async Task<BaseResponseObject<List<GraphUserOutput>>> SearchUsersAsync(SearchInput searchInput)

--- a/SafeExchange.Client.Web.Components/Pages/EditData.razor
+++ b/SafeExchange.Client.Web.Components/Pages/EditData.razor
@@ -549,7 +549,6 @@
 
         this.editContext = new EditContext(this.compoundModel);
         await this.FetchSecretAsync(this.ObjectName);
-        await this.StateContainer.TryFetchRegisteredApplications(this.apiClient);
         await this.StateContainer.TryFetchRegisteredGroups(this.apiClient);
     }
 

--- a/SafeExchange.PWA/Pages/RegisterS2SApp.razor
+++ b/SafeExchange.PWA/Pages/RegisterS2SApp.razor
@@ -67,6 +67,21 @@
         <ValidationMessage For="@(() => this.form.AadClientId)" class="text-danger small" />
     </div>
 
+    @if (this.allowedTenants.Count > 0)
+    {
+        <div class="mb-2">
+            <label class="form-label" for="aad-tenant-id">Tenant</label>
+            <select id="aad-tenant-id" class="form-select" @bind="this.form.AadTenantId">
+                <option value="">- Select a tenant -</option>
+                @foreach (var tenant in this.allowedTenants)
+                {
+                    <option value="@tenant.TenantId">@tenant.DisplayName</option>
+                }
+            </select>
+            <small class="form-text text-muted">The Entra tenant that issues your app's tokens. Only tenants approved for S2S are listed.</small>
+        </div>
+    }
+
     <p class="mt-3 mb-2"><strong>Co-owners:</strong></p>
     <ValidationMessage For="@(() => this.form.CoOwners)" class="text-danger small d-block mb-2" />
 
@@ -139,19 +154,39 @@
     private string? error;
     private RegisterForm form = new();
     private int currentOwnerIndex;
+    private List<S2SAllowedTenant> allowedTenants = new();
 
     private ItemSearchDialog<GraphUserOutput>? userPickDialog;
     private ItemSearchDialog<GraphGroupOutput>? groupPickDialog;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         this.StateContainer.SetCurrentPageHeader("Register S2S app");
         this.form.CoOwners.Add(new CoOwnerRow());
+
+        try
+        {
+            var response = await this.apiClient.GetS2SAllowedTenantsAsync();
+            if ("ok".Equals(response.Status) && response.Result is not null)
+            {
+                this.allowedTenants = response.Result;
+                // Preselect when there's exactly one choice so the user can't miss it.
+                if (this.allowedTenants.Count == 1)
+                {
+                    this.form.AadTenantId = this.allowedTenants[0].TenantId;
+                }
+            }
+        }
+        catch (AccessTokenNotAvailableException ex)
+        {
+            ex.Redirect();
+        }
     }
 
     private bool CanSubmit
         => !string.IsNullOrWhiteSpace(this.form.DisplayName)
         && !string.IsNullOrWhiteSpace(this.form.AadClientId)
+        && (this.allowedTenants.Count == 0 || !string.IsNullOrWhiteSpace(this.form.AadTenantId))
         && this.form.CoOwners.Any(o => !string.IsNullOrWhiteSpace(o.SubjectId));
 
     private void AddCoOwner()
@@ -238,7 +273,9 @@
     {
         if (!this.CanSubmit)
         {
-            this.error = "Display name, client id, and at least one co-owner are required.";
+            this.error = this.allowedTenants.Count > 0 && string.IsNullOrWhiteSpace(this.form.AadTenantId)
+                ? "Display name, client id, a tenant, and at least one co-owner are required."
+                : "Display name, client id, and at least one co-owner are required.";
             return;
         }
 
@@ -260,6 +297,7 @@
             {
                 DisplayName = this.form.DisplayName.Trim(),
                 AadClientId = this.form.AadClientId.Trim(),
+                AadTenantId = string.IsNullOrWhiteSpace(this.form.AadTenantId) ? null : this.form.AadTenantId,
                 AdditionalOwners = owners,
             };
 
@@ -300,6 +338,10 @@
         [Required(ErrorMessage = "Entra client id is required.")]
         [RegularExpression(GuidPattern, ErrorMessage = "Entra client id must be a GUID (00000000-0000-0000-0000-000000000000).")]
         public string AadClientId { get; set; } = string.Empty;
+
+        // Chosen from the allowed-tenants dropdown when the operator has configured an
+        // S2S allowlist; left empty (server defaults to the home tenant) otherwise.
+        public string AadTenantId { get; set; } = string.Empty;
 
         public List<CoOwnerRow> CoOwners { get; } = new();
 

--- a/SafeExchange.PWA/wwwroot/version.json
+++ b/SafeExchange.PWA/wwwroot/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.12",
+  "version": "1.0.13",
   "buildDate": ""
 }

--- a/docs/superpowers/specs/2026-06-28-s2s-cross-tenant-and-picker-design.md
+++ b/docs/superpowers/specs/2026-06-28-s2s-cross-tenant-and-picker-design.md
@@ -1,0 +1,209 @@
+# S2S cross-tenant access + application access-picker — design
+
+Date: 2026-06-28
+Status: Approved (brainstormed with the owner)
+Repos: `safeexchange` (backend, Azure Functions) and `safeexchange.blazorpwa` (Blazor WASM PWA + AdminPanel)
+Branch (both repos): `feature/s2s-cross-tenant-and-picker`
+
+## Problem
+
+A SafeExchange instance is configured to accept **user** tokens from a single
+"home" tenant (the customers/consumers tenant). A user from that tenant wants to
+run a **headless daemon** that authenticates to SafeExchange programmatically as
+a registered **S2S application**.
+
+Two things block this today:
+
+1. **Token validation is single-tenant.** `DefaultAuthenticationMiddleware`
+   validates every JWT against a single static `TokenValidationParameters` built
+   from `Authentication:ValidIssuers` + `MetadataAddress`, both pinned to one
+   tenant. A daemon token issued by the developer's **own** tenant fails issuer
+   validation (`401`, IDX10205) *before* the `(clientId, tenantId)` DB
+   registration in `TokenMiddlewareCore` is ever consulted. The personal/consumers
+   authority cannot mint client-credentials tokens at all, so a daemon **must**
+   use a real org tenant — which the instance currently rejects.
+
+2. **The registration UI cannot set a tenant.** `RegisterS2SApp.razor` collects
+   only display name + client id; the backend self-service endpoint already
+   accepts an optional `AadTenantId` but the form never sends one, so the app is
+   silently registered under the caller's sign-in tenant.
+
+Separately, when a user grants a secret's access to an application, the access
+editor offers a **dropdown** of all registered apps. The owner wants this to be a
+**search modal** (magnifying-glass icon) like the user/group pickers, searchable
+by name with client/tenant id shown for disambiguation.
+
+## Decision (owner's steer)
+
+- **Do NOT widen issuer trust to all tenants.** Keep user-token validation pinned
+  to the configured home tenant. Add a **fixed, configuration-time allowlist of
+  tenants from which app-only (S2S) tokens are accepted**. The registration UI
+  lets the user pick a tenant **from that list only** — never an arbitrary tenant.
+- **Replace the application dropdown with a search modal** backed by a new search
+  endpoint; all users can pick any previously-registered app by name.
+
+## Non-goals
+
+- No change to how user tokens are validated (home tenant only — unchanged).
+- No Microsoft Graph lookup for applications; application search is over the
+  locally-registered `Applications` only.
+- No automatic Entra app provisioning — operators do the Entra setup (below).
+
+## Backend design (`safeexchange`)
+
+### 1. S2S tenant allowlist configuration
+
+New property on `AuthenticationConfiguration` (`Authentication` config section):
+
+```
+Authentication:S2SAllowedTenants   (string, JSON array; default "" = feature off)
+```
+
+Value is a JSON array of `{ "tenantId": "<guid>", "displayName": "<label>" }`.
+Stored as a single Key Vault secret `Authentication--S2SAllowedTenants` so it
+fits the existing flat-settings deployment model. A pure, unit-tested parser
+(`S2SAllowedTenant.ParseList`) turns it into `IReadOnlyList<S2SAllowedTenant>`;
+malformed entries are skipped with a warning, non-GUID tenant ids rejected.
+
+`displayName` defaults to the tenant id when absent. Empty / missing config ⇒
+empty list ⇒ **feature is off and behavior is byte-for-byte identical to today**.
+
+### 2. Token-kind-aware issuer validation
+
+In `TokenValidationParametersProvider`:
+
+- Keep `ValidateIssuer = true`, `ValidAudiences`, lifetime, signed-token,
+  algorithm allowlist — unchanged.
+- When the allowlist is **empty**: keep the current behavior exactly, including
+  `EnableAadSigningKeyIssuerValidation()`. Zero regression for existing
+  instances (regular-tenant or customers-tenant) that don't use the feature.
+- When the allowlist is **non-empty**: install a custom `IssuerValidator`
+  delegate:
+  - **User tokens** (delegated; carry `scp`/`scope`): issuer must be one of the
+    configured `ValidIssuers` (home tenant) — unchanged restriction.
+  - **App-only tokens** (client-credentials; carry `appid`+`appidacr` or
+    `azp`+`azpacr`, no scope): issuer accepted if it is a configured issuer **or**
+    one derived from an allowlisted tenant — i.e. `https://login.microsoftonline.com/{tid}/v2.0`
+    or `https://sts.windows.net/{tid}/`.
+  - Otherwise → `SecurityTokenInvalidIssuerException` (surfaced as the generic
+    `401`, never echoing IDX text — existing CWE-209 hardening preserved).
+
+Token kind is classified by a shared, unit-tested helper
+(`TokenClassification.IsAppOnlyToken`) that `TokenHelper` is refactored to use
+too, so the auth layer and the validator can't drift.
+
+**Signing keys / security rationale.** Azure AD signs every worldwide-cloud
+tenant's tokens with the same published key set, and the `iss`/`tid` claims are
+themselves signed (tamper-proof). The existing `MetadataAddress` keys therefore
+validate the *signature* of an allowlisted-tenant token; the **signed issuer
+allowlist is the tenant gate**. `EnableAadSigningKeyIssuerValidation()` binds the
+key to the single configured issuer and would reject allowlisted tenants, so it
+is not applied when the allowlist is in use; its protection (relevant only to
+`common`/multi-tenant apps that trust tenant-supplied keys) is not meaningful for
+Microsoft-managed worldwide keys under a strict signed-issuer allowlist. Audience
+validation and the `(clientId, tenantId)` DB-registration gate remain in force as
+defense in depth. This trade-off is called out explicitly for security review.
+
+### 3. Allowed-tenants endpoint (for the registration UI)
+
+`GET /v2/s2sapps/allowed-tenants` — authenticated user; gated by
+`Features.S2SAppsSelfService` like the other `s2sapps` routes. Returns the
+`{ tenantId, displayName }` list (empty when the feature is off, so the UI can
+hide/disable the tenant control). Reads the parsed allowlist via
+`IOptionsMonitor<AuthenticationConfiguration>` (newly registered in DI).
+
+### 4. Tenant-constrained registration
+
+In `SafeExchangeS2SApps.RunRegister`:
+
+- When the allowlist is **non-empty**: the resolved `AadTenantId` must be a
+  member of the allowlist; otherwise `400` with a clear message. (The UI only
+  offers allowlisted tenants; this is the server-side enforcement.)
+- When the allowlist is **empty**: unchanged (defaults to caller's home tenant).
+
+The admin path (`POST /v2/applications/{id}`) is left flexible; the issuer
+allowlist remains the hard security boundary (an app registered for a
+non-allowlisted tenant simply can't authenticate).
+
+### 5. Application search endpoint
+
+`POST /v2/application-search` — mirrors `user-search`/`group-search`:
+
+- Authenticated **users only** (applications get `403`, like the other searches).
+- Body `SearchInput { searchString }`, validated by `SearchStringValidator`.
+- Searches **locally registered, enabled** `Applications` by `DisplayName`
+  (case-insensitive contains), capped (e.g. 50) and ordered by name.
+- Returns `List<ApplicationSearchOutput { DisplayName, AadClientId, AadTenantId }>`
+  so the picker can disambiguate multi-tenant apps.
+- Always available (no Graph feature flag — it reads the local DB).
+
+`GET /v2/applications-list` stays for backward compatibility.
+
+## Frontend design (`safeexchange.blazorpwa`)
+
+### 6. Tenant dropdown in `RegisterS2SApp.razor`
+
+- On init, call new `ApiClient.GetS2SAllowedTenantsAsync()` → `GET /v2/s2sapps/allowed-tenants`.
+- If the list is non-empty, render a required `<select>` of `{ displayName }`
+  (value = tenantId); preselect when there is exactly one. Bind the choice into
+  `S2SAppRegistrationRequest.AadTenantId` (the DTO already has the slot).
+- If empty (feature off), hide the control and behave as today (server defaults
+  to home tenant).
+
+### 7. Application search picker in `CreateData.razor` / `EditData.razor`
+
+- Replace the application-row `<InputSelect>` (bound to
+  `StateContainer.RegisteredApplications`) with a read-only `InputText` +
+  magnifying-glass button, mirroring the user/group rows.
+- Add an `ItemSearchDialog<Application>` instance with an `ItemTemplate` showing
+  `DisplayName` and, as secondary text, the client/tenant id.
+- New `ApiClient.SearchApplicationsAsync(SearchInput)` → `POST /v2/application-search`.
+- `Start…`/`Finish…` callbacks mirror the user/group ones; on pick, write the
+  app's `DisplayName` into both `SubjectName` and `SubjectId` (the access grant
+  keys on the globally-unique DisplayName, matching current server behavior).
+
+## Entra prerequisites (operator / owner, not code)
+
+For a daemon in the developer's own tenant to obtain a SafeExchange-audience
+token cross-tenant:
+
+1. The **SafeExchange API app registration must be multi-tenant**, so its service
+   principal can be provisioned (admin-consented) into the developer's tenant.
+2. It must **expose an app role** (e.g. `Access.AsApplication`) that is assigned
+   to the daemon app — Azure won't mint a `.default` app token for the SafeExchange
+   audience without at least one app-role assignment (SafeExchange itself only
+   checks the `(clientId, tenantId)` registration, not the role).
+3. The developer admin-consents both in their **own** tenant (where they are the
+   admin — this is why "no admin in the customers tenant" is no longer a blocker).
+
+## Backward compatibility
+
+- `Authentication:S2SAllowedTenants` empty ⇒ no new behavior anywhere; user-token
+  and existing app-token validation byte-for-byte unchanged; registration and the
+  app dropdown keep working. Regular-tenant instances are unaffected until an
+  operator opts in by populating the allowlist.
+
+## Testing strategy (red-green TDD)
+
+- `S2SAllowedTenant.ParseList`: valid JSON, empty/missing, malformed entries,
+  non-GUID tenant ids, display-name default.
+- `TokenClassification.IsAppOnlyToken`: v1 (appid/appidacr), v2 (azp/azpacr),
+  delegated-with-scope, mixed — and a test asserting `TokenHelper` agrees.
+- Issuer validation: empty allowlist ⇒ params identical to today (incl.
+  `EnableAadSigningKeyIssuerValidation`); non-empty ⇒ user token from an
+  allowlisted (non-home) tenant rejected, app token from an allowlisted tenant
+  accepted, app token from a non-allowlisted tenant rejected, home-tenant tokens
+  always accepted.
+- Registration: allowlisted tenant accepted; non-allowlisted rejected `400`;
+  empty allowlist ⇒ legacy default-to-home behavior.
+- `application-search`: forbids application callers; validates search string;
+  returns only enabled apps; disambiguation fields populated.
+- Frontend: build + targeted component checks where feasible.
+
+## Deployment / rollout
+
+1. Merge backend PR first (frontend depends on the new endpoints).
+2. Set `Authentication--S2SAllowedTenants` in the target Key Vault to the JSON
+   allowlist (staging: include tenant `1472703e-99d8-45ee-aeac-7ec3ae9ab104`).
+3. Ensure `Features:S2SAppsSelfService` is enabled for self-service registration.
+4. Complete the Entra prerequisites above for the daemon's tenant.

--- a/docs/superpowers/specs/2026-06-28-s2s-cross-tenant-and-picker-design.md
+++ b/docs/superpowers/specs/2026-06-28-s2s-cross-tenant-and-picker-design.md
@@ -106,7 +106,7 @@ defense in depth. This trade-off is called out explicitly for security review.
 
 ### 3. Allowed-tenants endpoint (for the registration UI)
 
-`GET /v2/s2sapps/allowed-tenants` — authenticated user; gated by
+`GET /v2/s2sapps-allowed-tenants` — authenticated user; gated by
 `Features.S2SAppsSelfService` like the other `s2sapps` routes. Returns the
 `{ tenantId, displayName }` list (empty when the feature is off, so the UI can
 hide/disable the tenant control). Reads the parsed allowlist via
@@ -143,7 +143,7 @@ non-allowlisted tenant simply can't authenticate).
 
 ### 6. Tenant dropdown in `RegisterS2SApp.razor`
 
-- On init, call new `ApiClient.GetS2SAllowedTenantsAsync()` → `GET /v2/s2sapps/allowed-tenants`.
+- On init, call new `ApiClient.GetS2SAllowedTenantsAsync()` → `GET /v2/s2sapps-allowed-tenants`.
 - If the list is non-empty, render a required `<select>` of `{ displayName }`
   (value = tenantId); preselect when there is exactly one. Bind the choice into
   `S2SAppRegistrationRequest.AadTenantId` (the DTO already has the slot).


### PR DESCRIPTION
## Summary

Frontend for the cross-tenant S2S feature. **Depends on backend PR yury-opolev/safeexchange#58** (new endpoints `GET /v2/s2sapps-allowed-tenants` and `POST /v2/application-search`) — merge/deploy backend first.

Design spec: `docs/superpowers/specs/2026-06-28-s2s-cross-tenant-and-picker-design.md`.

## What changed

- **`RegisterS2SApp.razor`** — adds a **tenant dropdown** populated from `GET /v2/s2sapps-allowed-tenants`, wired into `S2SAppRegistrationRequest.AadTenantId`. Preselects when there is exactly one allowed tenant; hidden when the allowlist is empty (server then defaults to the home tenant). `CanSubmit` requires a tenant only when the allowlist is non-empty.
- **`CreateData.razor` / `EditData.razor`** — replace the application `<InputSelect>` dropdown with a magnifying-glass `ItemSearchDialog<Application>` backed by `POST /v2/application-search`, mirroring the user/group pickers. Results show client/tenant id for disambiguation. Existing (fixed) access rows stay read-only. Removes the now-dead `TryFetchRegisteredApplications` round-trips.
- **`ApiClient`** — `SearchApplicationsAsync` + `GetS2SAllowedTenantsAsync`; `S2SAllowedTenant` client model.

## Testing

Solution builds clean. Reviewed against the existing user/group picker patterns (no NRE paths; accessibility labels present; fixed-row gating preserved). Behavior verification happens against the deployed staging backend.