### PR TITLE
fix(deploy): back up appsettings/version outside the project tree

### DIFF
--- a/deployment/deploy-adminpanel.ps1
+++ b/deployment/deploy-adminpanel.ps1
@@ -239,8 +239,12 @@ if (-not (Test-Path $srcAppsettings))
     throw "Source appsettings.json not found: $srcAppsettings"
 }
 
-$appsettingsBackup = "$srcAppsettings.deploy-bak"
-$versionBackup     = if (Test-Path $srcVersionJson) { "$srcVersionJson.deploy-bak" } else { $null }
+# Back up OUTSIDE the project tree (temp dir). A backup next to the source in
+# wwwroot exists during `dotnet publish` and can be swept into the published
+# output as a static web asset — and then SW-cached — shipping the
+# pre-injection appsettings.json. A temp path is never a publish input.
+$appsettingsBackup = Join-Path ([System.IO.Path]::GetTempPath()) ("appsettings.json.deploy-bak." + [guid]::NewGuid())
+$versionBackup     = if (Test-Path $srcVersionJson) { Join-Path ([System.IO.Path]::GetTempPath()) ("version.json.deploy-bak." + [guid]::NewGuid()) } else { $null }
 Copy-Item -LiteralPath $srcAppsettings -Destination $appsettingsBackup -Force
 if ($versionBackup) { Copy-Item -LiteralPath $srcVersionJson -Destination $versionBackup -Force }
 

--- a/deployment/deploy-pwa.ps1
+++ b/deployment/deploy-pwa.ps1
@@ -247,8 +247,12 @@ if (-not (Test-Path $srcAppsettings)) {
     throw "Source appsettings.json not found: $srcAppsettings"
 }
 
-$appsettingsBackup = "$srcAppsettings.deploy-bak"
-$versionBackup     = if (Test-Path $srcVersionJson) { "$srcVersionJson.deploy-bak" } else { $null }
+# Back up OUTSIDE the project tree (temp dir). A backup next to the source in
+# wwwroot exists during `dotnet publish` and can be swept into the published
+# output as a static web asset — and then SW-cached — shipping the
+# pre-injection appsettings.json. A temp path is never a publish input.
+$appsettingsBackup = Join-Path ([System.IO.Path]::GetTempPath()) ("appsettings.json.deploy-bak." + [guid]::NewGuid())
+$versionBackup     = if (Test-Path $srcVersionJson) { Join-Path ([System.IO.Path]::GetTempPath()) ("version.json.deploy-bak." + [guid]::NewGuid()) } else { $null }
 Copy-Item -LiteralPath $srcAppsettings -Destination $appsettingsBackup -Force
 if ($versionBackup) { Copy-Item -LiteralPath $srcVersionJson -Destination $versionBackup -Force }
 


### PR DESCRIPTION
Item 3 of the S2S self-review follow-ups (deploy hardening).

## Problem
`deploy-pwa.ps1` and `deploy-adminpanel.ps1` inject per-env appsettings values into the **source** `wwwroot/appsettings.json` before `dotnet publish`, having first backed the file up to `"<src>.deploy-bak"` — i.e. **next to the source, inside `wwwroot/`**. Because that backup exists during `dotnet publish`, it can be picked up as a static web asset and copied into the published output (`wwwroot/appsettings.json.deploy-bak`), and then cached by the PWA service worker. It holds the pre-injection `appsettings.json` — not secret, but it shouldn't ship. It also relies on the restore step running: a mid-publish failure leaves the `.deploy-bak` in the working tree.

## Fix
Back up to a GUID-named temp path **outside** the project tree (`[System.IO.Path]::GetTempPath()`), so the backup is never a publish input. Applied to both scripts. The restore blocks are unchanged — they already operate on the `$appsettingsBackup` / `$versionBackup` path variables.

## Verification
Both scripts parse cleanly (`[System.Management.Automation.Language.Parser]::ParseFile`). No behavior change beyond backup location; injection + try/finally restore logic is untouched.