### PR TITLE
Point web client at v3 API

### DIFF
--- a/SafeExchange.Client.Common.Tests/AccessApiClientTests.cs
+++ b/SafeExchange.Client.Common.Tests/AccessApiClientTests.cs
@@ -47,7 +47,7 @@ namespace SafeExchange.Client.Common.Tests
 
             Assert.That(handler.CapturedRequest, Is.Not.Null);
             Assert.That(handler.CapturedRequest!.Method, Is.EqualTo(new HttpMethod("PATCH")));
-            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v2/access/secret-1"));
+            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v3/access/secret-1"));
             Assert.That(response.Status, Is.EqualTo("ok"));
         }
 
@@ -112,7 +112,7 @@ namespace SafeExchange.Client.Common.Tests
 
             Assert.That(handler.CapturedRequest, Is.Not.Null);
             Assert.That(handler.CapturedRequest!.Method, Is.EqualTo(HttpMethod.Get));
-            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v2/access-giveup/secret-q"));
+            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v3/access-giveup/secret-q"));
             Assert.That(response.Status, Is.EqualTo("ok"));
             Assert.That(response.Result, Is.Not.Null);
             Assert.That(response.Result!.HasDirectRow, Is.True);
@@ -162,7 +162,7 @@ namespace SafeExchange.Client.Common.Tests
 
             Assert.That(handler.CapturedRequest, Is.Not.Null);
             Assert.That(handler.CapturedRequest!.Method, Is.EqualTo(HttpMethod.Delete));
-            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v2/access-giveup/secret-z"));
+            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v3/access-giveup/secret-z"));
             Assert.That(response.Status, Is.EqualTo("ok"));
             Assert.That(response.Result!.HadDirectRow, Is.True);
             Assert.That(response.Result!.WasOrphaned, Is.True);

--- a/SafeExchange.Client.Common.Tests/EffectivePermissionsApiClientTests.cs
+++ b/SafeExchange.Client.Common.Tests/EffectivePermissionsApiClientTests.cs
@@ -30,7 +30,7 @@ namespace SafeExchange.Client.Common.Tests
 
             var response = await client.ListSecretMetadataAsync();
 
-            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v2/secret-list"));
+            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v3/secret-list"));
             Assert.That(response.Status, Is.EqualTo("ok"));
             var item = response.Result!.Single();
 
@@ -55,7 +55,7 @@ namespace SafeExchange.Client.Common.Tests
 
             var response = await client.ListAccessAsync("sec-1");
 
-            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v2/access/sec-1"));
+            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v3/access/sec-1"));
             Assert.That(response.Status, Is.EqualTo("ok"));
 
             // The access list keeps each subject's actual permissions.

--- a/SafeExchange.Client.Common.Tests/PinnedSecretsApiClientTests.cs
+++ b/SafeExchange.Client.Common.Tests/PinnedSecretsApiClientTests.cs
@@ -26,7 +26,7 @@ namespace SafeExchange.Client.Common.Tests
             var response = await client.ListPinnedSecretsAsync();
 
             Assert.That(handler.CapturedRequest!.Method, Is.EqualTo(HttpMethod.Get));
-            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v2/pinnedsecrets-list"));
+            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v3/pinnedsecrets-list"));
             Assert.That(response.Status, Is.EqualTo("ok"));
             Assert.That(response.Result, Has.Count.EqualTo(2));
             Assert.That(response.Result![0].SecretName, Is.EqualTo("s1"));
@@ -54,7 +54,7 @@ namespace SafeExchange.Client.Common.Tests
             var response = await client.GetPinnedSecretAsync("s1");
 
             Assert.That(handler.CapturedRequest!.Method, Is.EqualTo(HttpMethod.Get));
-            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v2/pinnedsecrets/s1"));
+            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v3/pinnedsecrets/s1"));
             Assert.That(response.Status, Is.EqualTo("ok"));
             Assert.That(response.Result!.SecretName, Is.EqualTo("s1"));
         }
@@ -80,7 +80,7 @@ namespace SafeExchange.Client.Common.Tests
             var response = await client.PutPinnedSecretAsync("s1");
 
             Assert.That(handler.CapturedRequest!.Method, Is.EqualTo(HttpMethod.Put));
-            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v2/pinnedsecrets/s1"));
+            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v3/pinnedsecrets/s1"));
             Assert.That(handler.CapturedRequest!.Content, Is.Null);
             Assert.That(response.Status, Is.EqualTo("ok"));
         }
@@ -107,7 +107,7 @@ namespace SafeExchange.Client.Common.Tests
             var response = await client.DeletePinnedSecretAsync("s1");
 
             Assert.That(handler.CapturedRequest!.Method, Is.EqualTo(HttpMethod.Delete));
-            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v2/pinnedsecrets/s1"));
+            Assert.That(handler.CapturedRequest!.RequestUri!.AbsoluteUri, Does.EndWith("/api/v3/pinnedsecrets/s1"));
             Assert.That(response.Status, Is.EqualTo("ok"));
         }
 

--- a/SafeExchange.Client.Common/ApiClient/ApiClient.cs
+++ b/SafeExchange.Client.Common/ApiClient/ApiClient.cs
@@ -22,7 +22,7 @@ namespace SafeExchange.Client.Common
     {
         public static readonly string DefaultHttpClientName = "BackendApi";
 
-        public static readonly string ApiVersion = "v2";
+        public static readonly string ApiVersion = "v3";
 
         public const string ChunkHashHeaderName = "X-SafeExchange-Chunk-Hash";
 


### PR DESCRIPTION
Follow-up to #44. The backend now serves the enriched `secret-list` and `access` shapes under **v3** (v2 is frozen for older clients — see backend PR #61).

Flip the client's `ApiVersion` `v2` → `v3` so the PWA talks entirely to v3 and receives `SecretListItemOutput` / `AccessListOutput` (actual permissions for display + `callerEffectivePermissions` for capability checks). All endpoints answer on v3 via the backend's `{apiVersion}` route parameter, so this single-line switch is sufficient.

The not-yet-redeployed AdminPanel and any other old consumer keep working on v2.

Updated client test URL assertions to v3. 30 tests passing; full solution builds.

Backend counterpart: yury-opolev/safeexchange#61.