### PR TITLE
Show effective permissions for pinned secrets (v3)

### DIFF
--- a/SafeExchange.Client.Common.Tests/PinnedSecretModelTests.cs
+++ b/SafeExchange.Client.Common.Tests/PinnedSecretModelTests.cs
@@ -68,5 +68,24 @@ namespace SafeExchange.Client.Common.Tests
 
             Assert.That(model.PermissionsString, Is.EqualTo(string.Empty));
         }
+
+        [Test]
+        public void State_And_Permissions_FromEffective_WhenGroupOnlyReadable()
+        {
+            // Actual direct grant is empty, but the caller can read/write via a group, so the pinned
+            // secret is Live (not AccessLost) and shows the effective permissions.
+            var model = new PinnedSecret(new PinnedSecretListItemOutput
+            {
+                SecretName = "s6",
+                Exists = true,
+                CanRead = false,
+                CallerEffectivePermissions = new EffectivePermissions { CanRead = true, CanWrite = true },
+                Tags = new List<string> { "prod" }
+            });
+
+            Assert.That(model.State, Is.EqualTo(PinnedSecretState.Live));
+            Assert.That(model.PermissionsString, Is.EqualTo("Read,Write"));
+            Assert.That(model.Tags, Has.Member("prod"));
+        }
     }
 }

--- a/SafeExchange.Client.Common.Tests/PinnedSecretsApiClientTests.cs
+++ b/SafeExchange.Client.Common.Tests/PinnedSecretsApiClientTests.cs
@@ -19,7 +19,9 @@ namespace SafeExchange.Client.Common.Tests
         [Test]
         public async Task ListPinnedSecretsAsync_SendsGetAndParsesList()
         {
-            var body = "{\"status\":\"ok\",\"result\":[{\"secretName\":\"s1\",\"exists\":true,\"canRead\":true,\"tags\":[\"prod\"]},{\"secretName\":\"s2\",\"exists\":false,\"canRead\":false,\"tags\":[]}]}";
+            var body = "{\"status\":\"ok\",\"result\":[{\"secretName\":\"s1\",\"exists\":true,\"canRead\":false,\"tags\":[\"prod\"]," +
+                       "\"callerEffectivePermissions\":{\"canRead\":true,\"canWrite\":true,\"canGrantAccess\":false,\"canRevokeAccess\":false}}," +
+                       "{\"secretName\":\"s2\",\"exists\":false,\"canRead\":false,\"tags\":[]}]}";
             var handler = new CapturingHttpMessageHandler(HttpStatusCode.OK, body);
             var client = new ApiClient(new StubHttpClientFactory(handler));
 
@@ -31,6 +33,11 @@ namespace SafeExchange.Client.Common.Tests
             Assert.That(response.Result, Has.Count.EqualTo(2));
             Assert.That(response.Result![0].SecretName, Is.EqualTo("s1"));
             Assert.That(response.Result![0].Tags, Has.Member("prod"));
+
+            // Actual direct grant is empty; the caller's effective grant (via a group) is separate.
+            Assert.That(response.Result![0].CanRead, Is.False);
+            Assert.That(response.Result![0].CallerEffectivePermissions.CanRead, Is.True);
+            Assert.That(response.Result![0].CallerEffectivePermissions.CanWrite, Is.True);
         }
 
         [Test]

--- a/SafeExchange.Client.Common/ApiClient/ApiClient.cs
+++ b/SafeExchange.Client.Common/ApiClient/ApiClient.cs
@@ -795,8 +795,8 @@ namespace SafeExchange.Client.Common
 
         #region pinned secrets
 
-        public async Task<BaseResponseObject<List<PinnedSecretOutput>>> ListPinnedSecretsAsync()
-            => await this.ProcessResponseAsync<List<PinnedSecretOutput>>(async () =>
+        public async Task<BaseResponseObject<List<PinnedSecretListItemOutput>>> ListPinnedSecretsAsync()
+            => await this.ProcessResponseAsync<List<PinnedSecretListItemOutput>>(async () =>
             {
                 return await client.GetAsync($"{ApiVersion}/pinnedsecrets-list");
             });

--- a/SafeExchange.Client.Common/Model/Dto/Output/PinnedSecretListItemOutput.cs
+++ b/SafeExchange.Client.Common/Model/Dto/Output/PinnedSecretListItemOutput.cs
@@ -1,0 +1,33 @@
+/// <summary>
+/// PinnedSecretListItemOutput
+/// </summary>
+
+namespace SafeExchange.Client.Common.Model
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// One entry in the caller's pinned-secrets list (v3). The Can* flags are the caller's actual
+    /// direct grant; CallerEffectivePermissions is the effective grant (direct unioned with
+    /// group-derived), which the UI presents so a secret reachable only through a group still shows
+    /// as accessible rather than "no access".
+    /// </summary>
+    public class PinnedSecretListItemOutput
+    {
+        public string SecretName { get; set; } = string.Empty;
+
+        public bool Exists { get; set; }
+
+        public bool CanRead { get; set; }
+
+        public bool CanWrite { get; set; }
+
+        public bool CanGrantAccess { get; set; }
+
+        public bool CanRevokeAccess { get; set; }
+
+        public List<string> Tags { get; set; } = new List<string>();
+
+        public EffectivePermissions CallerEffectivePermissions { get; set; } = new();
+    }
+}

--- a/SafeExchange.Client.Common/Model/PinnedSecret.cs
+++ b/SafeExchange.Client.Common/Model/PinnedSecret.cs
@@ -22,6 +22,22 @@ namespace SafeExchange.Client.Common.Model
             this.Tags = source.Tags ?? new List<string>();
         }
 
+        // For a pinned secret the user cares about what they can effectively do with it, so the
+        // Live / "no access" state and permissions text are driven by the caller's effective grant
+        // (direct unioned with group-derived) rather than only a direct assignment.
+        public PinnedSecret(PinnedSecretListItemOutput source)
+        {
+            this.SecretName = source.SecretName;
+            this.Exists = source.Exists;
+
+            var effective = source.CallerEffectivePermissions ?? new EffectivePermissions();
+            this.CanRead = effective.CanRead;
+            this.CanWrite = effective.CanWrite;
+            this.CanGrantAccess = effective.CanGrantAccess;
+            this.CanRevokeAccess = effective.CanRevokeAccess;
+            this.Tags = source.Tags ?? new List<string>();
+        }
+
         public string SecretName { get; set; } = string.Empty;
 
         public bool Exists { get; set; }

--- a/SafeExchange.Client.Web.Components/Pages/Index.razor
+++ b/SafeExchange.Client.Web.Components/Pages/Index.razor
@@ -158,7 +158,7 @@
             var response = await this.apiClient.ListPinnedSecretsAsync();
             if ("ok".Equals(response.Status) || "no_content".Equals(response.Status))
             {
-                var items = response.Result ?? new List<PinnedSecretOutput>();
+                var items = response.Result ?? new List<PinnedSecretListItemOutput>();
                 this.pinnedSecrets = items.Select(x => new PinnedSecret(x)).ToList();
                 // Mutate the shared set in place (rather than reassigning) so the
                 // canonical instance is never orphaned for other readers.

--- a/SafeExchange.Client.Web.Components/Pages/ListData.razor
+++ b/SafeExchange.Client.Web.Components/Pages/ListData.razor
@@ -108,7 +108,7 @@
             var response = await this.apiClient.ListPinnedSecretsAsync();
             if ("ok".Equals(response.Status) || "no_content".Equals(response.Status))
             {
-                var items = response.Result ?? new List<PinnedSecretOutput>();
+                var items = response.Result ?? new List<PinnedSecretListItemOutput>();
                 this.StateContainer.PinnedSecretNames.Clear();
                 this.StateContainer.PinnedSecretNames.UnionWith(items.Select(p => p.SecretName));
             }


### PR DESCRIPTION
Backend counterpart: yury-opolev/safeexchange#62.

The pinned-secrets list now consumes the v3 `PinnedSecretListItemOutput`. A pinned secret the user can access **only via a group** is shown as **Live** (not "no access"), and its permissions text reflects the **effective** grant — for a pinned secret, the user cares about what they can effectively do with it.

- New client DTO `PinnedSecretListItemOutput` (actual `Can*` + `CallerEffectivePermissions`).
- `ApiClient.ListPinnedSecretsAsync` returns it; `PinnedSecret(PinnedSecretListItemOutput)` derives state/permissions from `CallerEffectivePermissions`. `Index`/`ListData` updated.
- Tests: pinned model state/permissions from effective; `ListPinnedSecretsAsync` wire contract for `callerEffectivePermissions`. 31 tests pass.