### PR TITLE
Client: fetch telemetry config on v3 (shared ApiVersion), not hardcoded v2

### DIFF
--- a/SafeExchange.Client.Web.Components/Classes/Telemetry/TelemetryService.cs
+++ b/SafeExchange.Client.Web.Components/Classes/Telemetry/TelemetryService.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
+using SafeExchange.Client.Common;
 
 /// <summary>
 /// Mediator between C# code and the window.saexTelemetry wrapper in
@@ -31,7 +32,9 @@ using Microsoft.JSInterop;
 /// </summary>
 public sealed class TelemetryService : IAsyncDisposable
 {
-    private const string ConfigEndpoint = "v2/telemetry/config";
+    // Derive from the shared client ApiVersion so this stays on the same version as every
+    // other backend call (v3) instead of pinning to a stale one.
+    private static readonly string ConfigEndpoint = $"{ApiClient.ApiVersion}/telemetry/config";
     private const string BackendApiClientName = "BackendApi";
 
     private readonly IJSRuntime jsRuntime;


### PR DESCRIPTION
`TelemetryService` hardcoded `v2/telemetry/config` while every other client call uses `ApiClient.ApiVersion` (v3). It worked only because the endpoint answers on both versions (the `{apiVersion}` route param), but it's inconsistent and would break if v2 is ever retired.

Fix: derive the path from the shared version — `$"{ApiClient.ApiVersion}/telemetry/config"` — so it tracks v3 automatically. Builds clean; no test asserted the old URL.