### PR TITLE
feat(build): inject PWA version at build time via -p:PwaVersion

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,40 @@
+<Project>
+
+  <!--
+    Build-time PWA version injection.
+
+    An external build pipeline (Azure DevOps, GitHub Actions, ...) can set the
+    web client version without editing any source file by passing PwaVersion:
+
+        dotnet publish SafeExchange.PWA -c Release -p:PwaVersion=2.3.4
+
+    Optionally pin the stamped date with -p:PwaBuildDate=2026-07-16; it defaults
+    to the UTC build date. When PwaVersion is not supplied the target is inert,
+    so a plain `dotnet build`, `dotnet run`, and deployment/deploy-pwa.ps1 keep
+    their existing version.json handling untouched.
+
+    The value is written into wwwroot/version.json BEFORE the build computes the
+    static-web-asset fingerprints and the service-worker integrity manifest, so
+    the cache-busting hashes shipped to the browser match the stamped content.
+    Only the project that owns wwwroot/version.json (the PWA host) is affected;
+    the target is a no-op in every other project in the tree.
+  -->
+
+  <PropertyGroup Condition="'$(PwaVersion)' != '' And '$(PwaBuildDate)' == ''">
+    <PwaBuildDate>$([System.DateTime]::UtcNow.ToString('yyyy-MM-dd'))</PwaBuildDate>
+  </PropertyGroup>
+
+  <Target Name="StampPwaVersion"
+          BeforeTargets="BeforeBuild"
+          Condition="'$(PwaVersion)' != '' And Exists('$(MSBuildProjectDirectory)\wwwroot\version.json')">
+    <!-- No Encoding attribute: WriteLinesToFile then defaults to UTF-8 without a
+         BOM, matching the BOM-less file the deploy script and source already use. -->
+    <WriteLinesToFile File="$(MSBuildProjectDirectory)\wwwroot\version.json"
+                      Lines="{ &quot;version&quot;: &quot;$(PwaVersion)&quot;, &quot;buildDate&quot;: &quot;$(PwaBuildDate)&quot; }"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
+    <Message Importance="high"
+             Text="PWA version stamped: $(PwaVersion) ($(PwaBuildDate)) -> $(MSBuildProjectDirectory)\wwwroot\version.json" />
+  </Target>
+
+</Project>

--- a/docs/build-versioning.md
+++ b/docs/build-versioning.md
@@ -1,0 +1,58 @@
+# Build-time version stamping
+
+The web client shows its version in the account menu (`SafeExchange.PWA/Shared/LoginDisplay.razor`),
+read at runtime from `wwwroot/version.json`:
+
+```json
+{ "version": "1.0.16", "buildDate": "2026-07-16" }
+```
+
+## Setting the version from a build pipeline
+
+Any external pipeline (Azure DevOps, GitHub Actions, ...) can stamp the version
+at build time without editing a single source file, by passing the `PwaVersion`
+MSBuild property:
+
+```bash
+dotnet publish SafeExchange.PWA -c Release -p:PwaVersion=2.3.4
+```
+
+The published `wwwroot/version.json` — and therefore the running UI — then reports
+`2.3.4`. Optionally pin the stamped date:
+
+```bash
+dotnet publish SafeExchange.PWA -c Release -p:PwaVersion=2.3.4 -p:PwaBuildDate=2026-07-16
+```
+
+`PwaBuildDate` defaults to the UTC build date when omitted.
+
+### Azure DevOps example
+
+```yaml
+- script: dotnet publish SafeExchange.PWA -c Release -p:PwaVersion=$(Build.BuildNumber)
+  displayName: Publish web client
+```
+
+### GitHub Actions example
+
+```yaml
+- run: dotnet publish SafeExchange.PWA -c Release -p:PwaVersion=${{ github.run_number }}
+```
+
+## How it works
+
+`Directory.Build.targets` (repo root) defines the `StampPwaVersion` target. It runs
+`BeforeTargets="BeforeBuild"` and rewrites `wwwroot/version.json` **before** the build
+computes the static-web-asset fingerprints and the service-worker integrity manifest,
+so the cache-busting hashes shipped to the browser match the stamped content.
+
+The target is **inert unless `PwaVersion` is supplied**, so:
+
+- a plain `dotnet build` / `dotnet run` leaves `version.json` untouched;
+- `deployment/deploy-pwa.ps1` keeps its existing auto-bump-and-commit behaviour
+  (it does not pass `PwaVersion`).
+
+Only the project that owns `wwwroot/version.json` (the PWA host) is affected; the
+target is a no-op in every other project in the tree. A repo that consumes this
+one can reuse the same `Directory.Build.targets` and `version.json` layout to get
+the same build-time knob.


### PR DESCRIPTION
## What

Adds a repo-root `Directory.Build.targets` with a `StampPwaVersion` target so an external build pipeline can set the web client version **at build time** without editing any source file:

```bash
dotnet publish SafeExchange.PWA -c Release -p:PwaVersion=2.3.4
```

The published `wwwroot/version.json` — and thus the running UI (account menu, `LoginDisplay.razor`) — then reports `2.3.4`. Optional `-p:PwaBuildDate=YYYY-MM-DD` pins the date (defaults to UTC build date).

## Why

Enables an ADO / GitHub Actions pipeline to `build → set version into web client` as part of CI, and lets other repos that reuse this layout get the same knob. Prep for the CI pipeline work.

## Behaviour

- **Inert unless `PwaVersion` is supplied** — plain `dotnet build` / `dotnet run` and `deploy-pwa.ps1` (which does not pass the property) keep their existing `version.json` handling untouched. Existing auto-bump-and-commit flow is unchanged.
- Rewrites `version.json` **before** static-web-asset fingerprinting + service-worker integrity manifest generation, so cache-busting hashes match the stamped content (same reason `deploy-pwa.ps1` stamps before publish).
- Writes BOM-less UTF-8 (matches the source file and the deploy script output).
- Only the project owning `wwwroot/version.json` (the PWA host) is affected; no-op elsewhere.

## Verification

- `dotnet msbuild -t:StampPwaVersion -p:PwaVersion=9.9.9` → `version.json` = `9.9.9`, no BOM (first bytes `7b 20 22 76`), parses cleanly.
- `dotnet build -c Debug -p:PwaVersion=8.8.8-buildhook` → `BeforeBuild` hook fires, file stamped, build succeeds.
- No `PwaVersion` → target does not run, `version.json` unchanged.

Docs: `docs/build-versioning.md`.

https://claude.ai/code/session_01HDbTJs2M17VF7s5C3NrkEK