### PR TITLE
ci: GitHub Actions build + test + artifact (web client)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+# Build + test on every push and pull request. On a push to main, also publish
+# the web-client artifact (version-stamped via the build-time PwaVersion knob).
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build & test (web client)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore SafeExchange.PWA.slnx
+
+      - name: Build
+        run: dotnet build SafeExchange.PWA.slnx -c Release --no-restore
+
+      - name: Test
+        run: dotnet test SafeExchange.PWA.slnx -c Release --no-build
+
+  publish:
+    name: Publish web client artifact
+    needs: build-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      # Base MAJOR.MINOR.PATCH from the committed version.json, plus the CI run
+      # number as build metadata, injected via the build-time PwaVersion knob
+      # (see docs/build-versioning.md and Directory.Build.targets).
+      - name: Resolve build version
+        id: ver
+        run: |
+          base=$(jq -r .version SafeExchange.PWA/wwwroot/version.json)
+          echo "pwa_version=${base}+ci.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish web client
+        run: dotnet publish SafeExchange.PWA -c Release -p:PwaVersion=${{ steps.ver.outputs.pwa_version }} -o publish
+
+      - name: Upload web client artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pwa-wwwroot-${{ github.run_number }}
+          path: publish/wwwroot
+          if-no-files-found: error


### PR DESCRIPTION
## What

Adds `.github/workflows/ci.yml` for the web client:

- **build-test** (every push + PR): restore, build `SafeExchange.PWA.slnx` in Release, run the client test suites (`SafeExchange.Client.Common.Tests` + `SafeExchange.Client.Web.Components.Tests`).
- **publish** (push to `main` only): `dotnet publish SafeExchange.PWA` and upload `wwwroot` as a build artifact.

No deployment from CI — deploys stay manual via `deployment/deploy-pwa.ps1`.

## Version stamping

The publish job uses the **build-time `PwaVersion` knob** (added in #48): it reads the base version from `version.json` and appends the CI run number as semver build metadata, e.g. `1.0.16+ci.42`, so the artifact's UI reports a traceable build. Client tests use stubbed HTTP — no emulator or secrets needed.

## Verified locally

- `dotnet test SafeExchange.PWA.slnx -c Release` discovers and passes both test projects (32 tests).
- `dotnet publish SafeExchange.PWA -c Release -p:PwaVersion=1.0.16+ci.1` produces `wwwroot/version.json` = `1.0.16+ci.1` (BOM-less), source tree restored.
- Workflow YAML parses cleanly.

Action versions use `@v4` tags; SHA-pinning is an easy follow-up hardening.

https://claude.ai/code/session_01HDbTJs2M17VF7s5C3NrkEK