### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     name: Build & test (web client)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '10.0.x'
 
@@ -40,10 +40,10 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '10.0.x'
 
@@ -60,7 +60,7 @@ jobs:
         run: dotnet publish SafeExchange.PWA -c Release -p:PwaVersion=${{ steps.ver.outputs.pwa_version }} -o publish
 
       - name: Upload web client artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pwa-wwwroot-${{ github.run_number }}
           path: publish/wwwroot


### PR DESCRIPTION
Pin `actions/checkout`, `actions/setup-dotnet`, `actions/upload-artifact` to full commit SHAs (with `# v4.x` comments) instead of mutable `@v4` tags, so a retagged/compromised action can't silently alter the build.

- checkout → `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
- setup-dotnet → `67a3573c9a986a3f9c594539f4ab511d57bb3ce9` (v4.3.1)
- upload-artifact → `ea165f8d65b6e75b540449e92b4886f43607fa02` (v4.6.2)

No behavior change. Matches the backend hardening PR.

https://claude.ai/code/session_01HDbTJs2M17VF7s5C3NrkEK