### PR TITLE
fix(client): tolerate null EffectivePermissions in ObjectMetadata copy

### DIFF
--- a/SafeExchange.Client.Common.Tests/EffectivePermissionsApiClientTests.cs
+++ b/SafeExchange.Client.Common.Tests/EffectivePermissionsApiClientTests.cs
@@ -102,5 +102,25 @@ namespace SafeExchange.Client.Common.Tests
             Assert.That(copy.EffectivePermissions.CanWrite, Is.True);
             Assert.That(copy.EffectivePermissions.CanGrantAccess, Is.False);
         }
+
+        [Test]
+        public void ObjectMetadata_CopyConstructor_NullEffectivePermissions_YieldsNoCapabilityCopy()
+        {
+            var source = new ObjectMetadata
+            {
+                ObjectName = "sec-4",
+                Content = new List<ContentMetadata>(),
+                ExpirationMetadata = new ExpirationMetadata(),
+                EffectivePermissions = null!, // simulate a caller violating the non-null contract
+            };
+
+            var copy = new ObjectMetadata(source);
+
+            Assert.That(copy.EffectivePermissions, Is.Not.Null);
+            Assert.That(copy.EffectivePermissions.CanRead, Is.False);
+            Assert.That(copy.EffectivePermissions.CanWrite, Is.False);
+            Assert.That(copy.EffectivePermissions.CanGrantAccess, Is.False);
+            Assert.That(copy.EffectivePermissions.CanRevokeAccess, Is.False);
+        }
     }
 }

--- a/SafeExchange.Client.Common.Tests/EffectivePermissionsApiClientTests.cs
+++ b/SafeExchange.Client.Common.Tests/EffectivePermissionsApiClientTests.cs
@@ -111,7 +111,7 @@ namespace SafeExchange.Client.Common.Tests
                 ObjectName = "sec-4",
                 Content = new List<ContentMetadata>(),
                 ExpirationMetadata = new ExpirationMetadata(),
-                EffectivePermissions = null!, // simulate a caller violating the non-null contract
+                EffectivePermissions = null!,
             };
 
             var copy = new ObjectMetadata(source);

--- a/SafeExchange.Client.Common/Model/ObjectMetadata.cs
+++ b/SafeExchange.Client.Common/Model/ObjectMetadata.cs
@@ -24,12 +24,16 @@ namespace SafeExchange.Client.Common.Model
 
             this.AuditEnabled = source.AuditEnabled;
 
+            // Nullable annotations are not enforced at runtime, so a caller can still assign
+            // null to the source property; copying restores the no-capability default instead
+            // of throwing.
+            var sourceEffectivePermissions = source.EffectivePermissions ?? new EffectivePermissions();
             this.EffectivePermissions = new EffectivePermissions
             {
-                CanRead = source.EffectivePermissions.CanRead,
-                CanWrite = source.EffectivePermissions.CanWrite,
-                CanGrantAccess = source.EffectivePermissions.CanGrantAccess,
-                CanRevokeAccess = source.EffectivePermissions.CanRevokeAccess,
+                CanRead = sourceEffectivePermissions.CanRead,
+                CanWrite = sourceEffectivePermissions.CanWrite,
+                CanGrantAccess = sourceEffectivePermissions.CanGrantAccess,
+                CanRevokeAccess = sourceEffectivePermissions.CanRevokeAccess,
             };
         }
 

--- a/SafeExchange.Client.Common/Model/ObjectMetadata.cs
+++ b/SafeExchange.Client.Common/Model/ObjectMetadata.cs
@@ -24,16 +24,12 @@ namespace SafeExchange.Client.Common.Model
 
             this.AuditEnabled = source.AuditEnabled;
 
-            // Nullable annotations are not enforced at runtime, so a caller can still assign
-            // null to the source property; copying restores the no-capability default instead
-            // of throwing.
-            var sourceEffectivePermissions = source.EffectivePermissions ?? new EffectivePermissions();
             this.EffectivePermissions = new EffectivePermissions
             {
-                CanRead = sourceEffectivePermissions.CanRead,
-                CanWrite = sourceEffectivePermissions.CanWrite,
-                CanGrantAccess = sourceEffectivePermissions.CanGrantAccess,
-                CanRevokeAccess = sourceEffectivePermissions.CanRevokeAccess,
+                CanRead = source.EffectivePermissions?.CanRead ?? false,
+                CanWrite = source.EffectivePermissions?.CanWrite ?? false,
+                CanGrantAccess = source.EffectivePermissions?.CanGrantAccess ?? false,
+                CanRevokeAccess = source.EffectivePermissions?.CanRevokeAccess ?? false,
             };
         }
 


### PR DESCRIPTION
Implements item 4 (optional defensive hardening) from the "Propositions - 01" improvement backlog (reviewed revision aad8c20).

`ObjectMetadata`''s copy constructor dereferenced `source.EffectivePermissions` directly. The property is non-nullable and every in-repo call site preserves that invariant, but nullable annotations are not enforced at runtime — external code assigning `null` would crash the copy. The constructor now copies from a no-capability default when the source value is null.

Tests: new null-source case (yields a non-null no-capability copy) alongside the existing flag-preservation and from-output default cases. Client.Common 32/32 and Web.Components suites green.

https://claude.ai/code/session_018vsxd6pk2k4UFwtKo1oYur